### PR TITLE
add testing on pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "webpack --config webpack.prod.babel.js",
     "test": "./node_modules/.bin/mocha"
   },
+  "pre-commit": "test",
   "engines": {
     "node": "~5.10.1",
     "npm": "3.8.3"
@@ -75,6 +76,7 @@
     "mocha": "^3.2.0",
     "mocha-jsdom": "^1.1.0",
     "nodemon": "^1.11.0",
+    "pre-commit": "^1.2.2",
     "react-addons-test-utils": "^15.4.2",
     "react-hot-loader": "^1.3.1",
     "webpack": "^2.2.1",


### PR DESCRIPTION
This runs npm test before every commit, to ensure we're testing.

You can skip the test by running `git commit -n` or `git commit --no-verify`