### PR TITLE
add title bar to logged out state

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "pre-commit": "^1.2.2",
     "react-addons-test-utils": "^15.4.2",
     "react-hot-loader": "^1.3.1",
+    "sinon": "^1.17.7",
     "webpack": "^2.2.1",
     "webpack-dev-server": "^2.4.1"
   }

--- a/src/components/home/logged-out.jsx
+++ b/src/components/home/logged-out.jsx
@@ -1,9 +1,38 @@
 import React from 'react';
 
-const LoggedOutHome = () => (
-  <div>
-    logged out wew
-  </div>
-);
+import TitleBar from 'components/title_bar/title_bar';
+import TitleBarItem, { TitleBarItemTypes } from 'components/title_bar/title_bar_item';
 
-export default LoggedOutHome;
+export default class LoggedOutHome extends React.PureComponent {
+  renderTitleBar() {
+    const applyLink = (
+      <TitleBarItem
+        text="Apply"
+        type={TitleBarItemTypes.LINK}
+        href="#"
+        key={1}
+      />
+    );
+    const loginLink = (
+      <TitleBarItem
+        text="Log in"
+        type={TitleBarItemTypes.LINK}
+        href="#"
+        key={2}
+      />
+    );
+    const rightItems = [loginLink, applyLink];
+    return <TitleBar rightItems={rightItems} />;
+  }
+
+  render() {
+    return (
+      <div>
+        {this.renderTitleBar()}
+        <div className="body-with-title-bar container">
+          logged out wew
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/components/title_bar/title_bar.jsx
+++ b/src/components/title_bar/title_bar.jsx
@@ -4,11 +4,13 @@ export default class TitleBar extends React.PureComponent {
   render() {
     return (
       <div className="title-bar">
-        <div className="title-bar__left">
-          {this.props.leftItems}
-        </div>
-        <div className="title-bar__right">
-          {this.props.rightItems}
+        <div className="container title-bar__container">
+          <div className="title-bar__items float-left">
+              {this.props.leftItems}
+          </div>
+          <div className="title-bar__items float-right">
+            {this.props.rightItems}
+          </div>
         </div>
       </div>
     );

--- a/src/components/title_bar/title_bar.jsx
+++ b/src/components/title_bar/title_bar.jsx
@@ -6,7 +6,7 @@ export default class TitleBar extends React.PureComponent {
       <div className="title-bar">
         <div className="container title-bar__container">
           <div className="title-bar__items float-left">
-              {this.props.leftItems}
+            {this.props.leftItems}
           </div>
           <div className="title-bar__items float-right">
             {this.props.rightItems}

--- a/src/components/title_bar/title_bar_item.jsx
+++ b/src/components/title_bar/title_bar_item.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+const linkClassName = 'link';
+
+export const TitleBarItemTypes = {
+  LINK: 'link',
+  BUTTON: 'button',
+};
+
+const TitleBarItemTypeValues = Object.keys(TitleBarItemTypes).map((key) => TitleBarItemTypes[key]);
+
+export default class TitleBarItem extends React.PureComponent {
+  render() {
+    let item = null;
+    if (this.props.type === TitleBarItemTypes.LINK) {
+      item = (
+        <a
+          href={this.props.href}
+          className={linkClassName}
+        >
+          {this.props.text}
+        </a>
+      );
+    } else if (this.props.type === TitleBarItemTypes.BUTTON) {
+      item = (
+        <button
+          onClick={this.props.onClick}
+          className={linkClassName}
+        >
+          {this.props.text}
+        </button>
+      );
+    }
+    return (
+      <div className="title-bar__item">
+        {item}
+      </div>
+    );
+  }
+}
+
+TitleBarItem.propTypes = {
+  type: React.PropTypes.oneOf(TitleBarItemTypeValues).isRequired,
+  text: React.PropTypes.string.isRequired,
+  href: React.PropTypes.string,
+  onClick: React.PropTypes.func,
+};

--- a/src/stylesheets/components/title_bar.less
+++ b/src/stylesheets/components/title_bar.less
@@ -7,10 +7,26 @@
   height: @title_bar_height;
   background-color: @color_primary;
   color: white;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 15px;
+
+  &__container {
+    height: 100%;
+  }
+
+  &__items {
+    display: flex;
+    height: 100%;
+  }
+
+  &__item {
+    padding: 1rem;
+    display: flex;
+    align-items: center;
+
+    .link {
+      color: white;
+      text-decoration: none;
+    }
+  }
 }
 
 .body-with-title-bar {

--- a/src/stylesheets/main.less
+++ b/src/stylesheets/main.less
@@ -17,3 +17,11 @@ body {
   font: 14px/1 "Oxygen", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
   line-height: 1.42857143;
 }
+
+.float-left {
+  float: left;
+}
+
+.float-right {
+  float: right;
+}

--- a/test/components/title_bar/title_bar.test.js
+++ b/test/components/title_bar/title_bar.test.js
@@ -1,11 +1,11 @@
-import { mockDOM, setupDOM } from './../frontend_utils';
+import { mockDOM, setupDOM } from './../../frontend_utils';
 mockDOM();
 
 import { expect } from 'chai';
 
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
-import TitleBar from './../../src/components/title_bar';
+import TitleBar from './../../../src/components/title_bar/title_bar';
 
 describe('TitleBar', () => {
   setupDOM();

--- a/test/components/title_bar/title_bar_item.test.js
+++ b/test/components/title_bar/title_bar_item.test.js
@@ -1,0 +1,77 @@
+import { mockDOM, setupDOM } from './../../frontend_utils';
+mockDOM();
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import TitleBarItem, { TitleBarItemTypes } from './../../../src/components/title_bar/title_bar_item';
+
+const ce = React.createElement;
+
+describe('TitleBarItem', () => {
+  setupDOM();
+  let props;
+  let text;
+
+  beforeEach(() => {
+    text = 'hello';
+    props = { text };
+  });
+
+  describe('render', () => {
+    describe('link type', () => {
+      let href;
+      let anchor;
+
+      beforeEach(() => {
+        href = '#';
+        props.href = href;
+        props.type = TitleBarItemTypes.LINK;
+        const component = TestUtils.renderIntoDocument(ce(TitleBarItem, props));
+        anchor = TestUtils.findRenderedDOMComponentWithTag(component, 'a');
+      });
+
+      it('renders an anchor tag', () => {
+        expect(anchor).to.not.be.undefined;
+      });
+
+      it('renders correct text', () => {
+        expect(anchor.innerHTML).to.equal(text);
+      });
+
+      it('has correct href attribute', () => {
+        expect(anchor.getAttribute('href')).to.equal(href);
+      });
+    });
+
+    describe('button type', () => {
+      let onClick;
+      let button;
+
+      beforeEach(() => {
+        onClick = sinon.spy();
+        props.type = TitleBarItemTypes.BUTTON;
+        props.onClick = onClick;
+        const component = TestUtils.renderIntoDocument(ce(TitleBarItem, props));
+        button = TestUtils.findRenderedDOMComponentWithTag(component, 'button');
+      });
+
+      it('renders an button tag', () => {
+        expect(button).to.not.be.undefined;
+      });
+
+      it('renders correct text', () => {
+        expect(button.innerHTML).to.equal(text);
+      });
+
+      it('has correct onClick function', () => {
+        expect(onClick.calledOnce).to.be.false;
+        TestUtils.Simulate.click(button);
+        expect(onClick.calledOnce).to.be.true;
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
![screenshot 2017-03-12 at 9 33 16 pm](https://cloud.githubusercontent.com/assets/8731183/23838404/af2a643e-076b-11e7-99af-e91f642666a9.png)

Adds title bar to logged out page. Makes it easier to add things to the title bar. Also makes the title bar respect container sizes.

Added testing.