### PR TITLE
make footer padding consistent with page

### DIFF
--- a/src/components/footer/footer.jsx
+++ b/src/components/footer/footer.jsx
@@ -5,26 +5,28 @@ export default class Footer extends React.PureComponent {
     return (
       <div className="footer">
         <div className="container">
-          <div className="col-sm-12 col-md-2 info-link">
-            <div className="sponser">
-              Want to Sponser?
+          <div className="row">
+            <div className="col-sm-12 col-md-2 info-link">
+              <div className="sponser">
+                Want to Sponser?
+              </div>
+              <div className="questions">
+                Have questions?
+              </div>
+              <div className="email">
+                team@alumni.com
+              </div>
             </div>
-            <div className="questions">
-              Have questions?
-            </div>
-            <div className="email">
-              team@alumni.com
-            </div>
-          </div>
-          <div className="col-sm-12 col-md-2 contact-link">
-            <div>
-              About
-            </div>
-            <div>
-              Contribute
-            </div>
-            <div>
-              Apply
+            <div className="col-sm-12 col-md-2 contact-link">
+              <div>
+                About
+              </div>
+              <div>
+                Contribute
+              </div>
+              <div>
+                Apply
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/footer/footer.jsx
+++ b/src/components/footer/footer.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 export default class Footer extends React.PureComponent {
   render() {
     return (
-      <div className="footer container">
-        <div className="row">
+      <div className="footer">
+        <div className="container">
           <div className="col-sm-12 col-md-2 info-link">
             <div className="sponser">
               Want to Sponser?

--- a/src/stylesheets/footer.less
+++ b/src/stylesheets/footer.less
@@ -1,14 +1,14 @@
-@import 'constants.less';
+@footer_padding: 2rem;
 
 .footer {
   position: absolute;
   right: 0;
   bottom: 0;
   left: 0;
-  padding: 3rem;
+  padding-top: @footer_padding;
+  padding-bottom: @footer_padding;
   color: @color_text-dark;
   background-color: @color_secondary;
-  width: 100%;
   .sponser {
     font-style: italic;
   }


### PR DESCRIPTION
Separate container to be it's own level div so that the side padding lines up with the rest of the page (body, title bar).

Also reduced top and bottom padding of the titlebar (total nit).


![screenshot 2017-03-25 at 2 24 14 pm](https://cloud.githubusercontent.com/assets/8731183/24324994/dd3a0c58-1166-11e7-8e77-e091c47ae8fd.png)
